### PR TITLE
feat: link GTM template alongside script SDK in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ yarn add @convivainc/conviva-js-appanalytics
 ```
 <!-- ::: -->
 
-**Note**: For script-based integrations, refer [Conviva JS Script DPI SDK](https://github.com/Conviva/conviva-js-script-appanalytics) for guidelines.
+**Note**: For script-based integrations, refer [Conviva JS Script DPI SDK](https://github.com/Conviva/conviva-js-script-appanalytics) for guidelines. For Google Tag Manager–based integrations, refer to the [Conviva DPI JS SDK GTM template](https://tagmanager.google.com/gallery/#/owners/Conviva/templates/conviva-dpi-js-sdk-gtm).
  <!--eof-self-serve--> 
 
 ### 2. Initialization


### PR DESCRIPTION
## Summary

Extend the existing cross-reference note in the Quick Start section of the NPM README so that users discovering Conviva DPI via the NPM package can also find:

- The script-based variant (already linked).
- The **Conviva DPI JS SDK GTM template** in the Google Tag Manager gallery — newly added.

This was requested by Max Hakansson on `#app_sensor` so customers integrating via GTM aren't a hidden third path.

## Change

`README.md`, Quick Start → Installation note:

Before:
> **Note**: For script-based integrations, refer [Conviva JS Script DPI SDK](https://github.com/Conviva/conviva-js-script-appanalytics) for guidelines.

After:
> **Note**: For script-based integrations, refer [Conviva JS Script DPI SDK](https://github.com/Conviva/conviva-js-script-appanalytics) for guidelines. For Google Tag Manager–based integrations, refer to the [Conviva DPI JS SDK GTM template](https://tagmanager.google.com/gallery/#/owners/Conviva/templates/conviva-dpi-js-sdk-gtm).

A symmetric note is being added to the script repo (`conviva-js-script-appanalytics`) in a separate PR.

## Test plan

- [x] Markdown renders cleanly (link targets, em-dash, no broken anchors).
- [x] No content removed; only the existing note paragraph extended.
- [ ] Reviewer confirms the GTM gallery URL is the canonical link we want to advertise.